### PR TITLE
Use relative import statements.

### DIFF
--- a/radiotap/__init__.py
+++ b/radiotap/__init__.py
@@ -1,1 +1,1 @@
-from radiotap import radiotap_parse, ieee80211_parse
+from .radiotap import radiotap_parse, ieee80211_parse

--- a/radiotap/radiotap.py
+++ b/radiotap/radiotap.py
@@ -9,7 +9,7 @@
 # >>> off, mac = r.ieee80211_parse(pkt, off)
 import struct
 
-from vht import *
+from .vht import *
 
 
 mcs_rate_table = [


### PR DESCRIPTION
Ensures compatibility with Python 3.

Fixes #5.