### PR TITLE
Tests: make parse.py compatible with both Python 2.7 and 3

### DIFF
--- a/tests/parse.py
+++ b/tests/parse.py
@@ -8,6 +8,16 @@ cases.
 import radiotap as r
 import sys
 
+# iterbytes is adapted from the six module
+# Copyright (c) 2010-2020 Benjamin Peterson
+# https://github.com/benjaminp/six/
+if sys.version_info[0] == 3:
+    iterbytes = iter
+else:
+    import functools
+    import itertools
+    iterbytes = functools.partial(itertools.imap, ord)
+
 fields_to_print = {
     'TSFT': [ 'TSFT', lambda x : x ],
     'flags': [ 'flags', lambda x : '%x' % x ],
@@ -16,7 +26,7 @@ fields_to_print = {
 }
 
 def datastr(data, sep):
-    return sep.join('%.2x' % ord(k) for k in data)
+    return sep.join('%.2x' % k for k in iterbytes(data))
 
 def print_vendor(row):
     """ Print vendor lines that match what parse.c does
@@ -28,15 +38,15 @@ def print_vendor(row):
         (row['present'] & (1 << 52))):
 
         bit = 0 if (row['present'] & (1 << 0)) else 52
-        print '\t%s-%.2x|%d: %s' % (
-             datastr(oui, ':'), row['subns'], bit, datastr(data, '/'))
+        print('\t%s-%.2x|%d: %s' % (
+             datastr(oui, ':'), row['subns'], bit, datastr(data, '/')))
     elif row['subns'] != 0:
-        print '\tvendor NS (%s:%d, %d bytes)\n\t\t%s' % (
+        print('\tvendor NS (%s:%d, %d bytes)\n\t\t%s' % (
              datastr(oui, '-'), row['subns'], len(data),
-             datastr(data, ' '))
+             datastr(data, ' ')))
 
 def parse_file(fn):
-    pkt = open(fn).read()
+    pkt = open(fn, 'rb').read()
 
     while len(pkt):
         off, radiotap = r.radiotap_parse(pkt, valuelist=True)
@@ -46,13 +56,13 @@ def parse_file(fn):
             for k,v in row.items():
                 if k in fields_to_print:
                     lbl, fmt = fields_to_print[k]
-                    print '\t%s: %s' % (lbl, fmt(v))
+                    print('\t%s: %s' % (lbl, fmt(v)))
         pkt = pkt[off:]
 
 if __name__ == "__main__":
 
     if len(sys.argv) < 2:
-        print "Usage: %s [file]" % sys.argv[0]
+        print("Usage: %s [file]" % sys.argv[0])
         sys.exit(1)
 
     parse_file(sys.argv[1])


### PR DESCRIPTION
Update tests/parse.py to work under both Python 2.7 and 3.

Fixes #7 